### PR TITLE
fixed bug - WiFiClientSecure has no member setCACert

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=detaBaseArduinoESP32
-version=1.0.0
+version=1.0.2
 author=Kushagra Goel <kushagra.goel@mail.utoronto.ca>
 maintainer=Kushagra Goel <kushagra.goel@mail.utoronto.ca>
 sentence=Makes working with Deta.sh Base easy

--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Abstracts away all the internet and requests stuff
 category=Communication
 url=https://github.com/A223D/detaBaseArduinoESP32
 architectures=esp32, esp8266
+includes=WiFiClientSecure.h

--- a/src/detaBaseArduinoESP32.cpp
+++ b/src/detaBaseArduinoESP32.cpp
@@ -7,7 +7,9 @@ DetaBaseObject::DetaBaseObject(WiFiClientSecure wifiObject, const char* detaID, 
   _detaBaseName = detaBaseName;
   _baseURI = (char *)malloc((strlen("/v1/") + strlen(detaID) + strlen("/") + strlen(detaBaseName) + 1 ) * sizeof(char));
   _wifiObject = wifiObject;
-  _wifiObject.setCACert(_detaRootCa);
+  // _wifiObject.setCACert(_detaRootCa);
+  _wifiObject.setFingerprint(fingerprint);
+  _wifiObject.setTimeout(15000);  // 15 Seconds
   _host = "database.deta.sh";
   strcpy(_baseURI, "/v1/");
   strncat(_baseURI, detaID, strlen(detaID));
@@ -21,7 +23,9 @@ DetaBaseObject::DetaBaseObject(WiFiClientSecure wifiObject, const char* detaID, 
   _detaBaseName = detaBaseName;
   _baseURI = (char *)malloc((strlen("/v1/") + strlen(detaID) + strlen("/") + strlen(detaBaseName) + 1 ) * sizeof(char));
   _wifiObject = wifiObject;
-  _wifiObject.setCACert(_detaRootCa);
+  // _wifiObject.setCACert(_detaRootCa);
+  _wifiObject.setFingerprint(fingerprint);
+  _wifiObject.setTimeout(15000);  // 15 Seconds
   _host = "database.deta.sh";
   strcpy(_baseURI, "/v1/");
   strncat(_baseURI, detaID, strlen(detaID));

--- a/src/detaBaseArduinoESP32.cpp
+++ b/src/detaBaseArduinoESP32.cpp
@@ -8,8 +8,6 @@ DetaBaseObject::DetaBaseObject(WiFiClientSecure wifiObject, const char* detaID, 
   _baseURI = (char *)malloc((strlen("/v1/") + strlen(detaID) + strlen("/") + strlen(detaBaseName) + 1 ) * sizeof(char));
   _wifiObject = wifiObject;
   // _wifiObject.setCACert(_detaRootCa);
-  _wifiObject.setFingerprint(fingerprint);
-  _wifiObject.setTimeout(15000);  // 15 Seconds
   _host = "database.deta.sh";
   strcpy(_baseURI, "/v1/");
   strncat(_baseURI, detaID, strlen(detaID));
@@ -24,8 +22,6 @@ DetaBaseObject::DetaBaseObject(WiFiClientSecure wifiObject, const char* detaID, 
   _baseURI = (char *)malloc((strlen("/v1/") + strlen(detaID) + strlen("/") + strlen(detaBaseName) + 1 ) * sizeof(char));
   _wifiObject = wifiObject;
   // _wifiObject.setCACert(_detaRootCa);
-  _wifiObject.setFingerprint(fingerprint);
-  _wifiObject.setTimeout(15000);  // 15 Seconds
   _host = "database.deta.sh";
   strcpy(_baseURI, "/v1/");
   strncat(_baseURI, detaID, strlen(detaID));

--- a/src/detaBaseArduinoESP32.h
+++ b/src/detaBaseArduinoESP32.h
@@ -43,6 +43,7 @@ class DetaBaseObject {
     void writeNonPayloadHeaders();
     void writePayloadHeaders(const char* object);
     void initResult(result* resultObject);
+    const char fingerprint[] PROGMEM = "4B C7 8E E0 6B F4 8D 57 B4 2D 59 49 C1 8B CA EE 1D 2A F0 F4";
     const char* const _detaRootCa = \
                                     "-----BEGIN CERTIFICATE-----\n" \
                                     "MIIF3jCCA8agAwIBAgIQAf1tMPyjylGoG7xkDjUDLTANBgkqhkiG9w0BAQwFADCB\n" \

--- a/src/detaBaseArduinoESP32.h
+++ b/src/detaBaseArduinoESP32.h
@@ -43,7 +43,6 @@ class DetaBaseObject {
     void writeNonPayloadHeaders();
     void writePayloadHeaders(const char* object);
     void initResult(result* resultObject);
-    const char fingerprint[] PROGMEM = "4B C7 8E E0 6B F4 8D 57 B4 2D 59 49 C1 8B CA EE 1D 2A F0 F4";
     const char* const _detaRootCa = \
                                     "-----BEGIN CERTIFICATE-----\n" \
                                     "MIIF3jCCA8agAwIBAgIQAf1tMPyjylGoG7xkDjUDLTANBgkqhkiG9w0BAQwFADCB\n" \


### PR DESCRIPTION
c:\Users\mikda\Documents\Arduino\libraries\detaBaseArduinoESP32\src\detaBaseArduinoESP32.cpp: In constructor 'DetaBaseObject::DetaBaseObject(BearSSL::WiFiClientSecure, const char*, const char*, const char*, bool)':
c:\Users\mikda\Documents\Arduino\libraries\detaBaseArduinoESP32\src\detaBaseArduinoESP32.cpp:10:15: error: 'class BearSSL::WiFiClientSecure' has no member named 'setCACert'
   10 |   _wifiObject.setCACert(_detaRootCa);
      |               ^~~~~~~~~
c:\Users\mikda\Documents\Arduino\libraries\detaBaseArduinoESP32\src\detaBaseArduinoESP32.cpp: In constructor 'DetaBaseObject::DetaBaseObject(BearSSL::WiFiClientSecure, const char*, const char*, const char*)':
c:\Users\mikda\Documents\Arduino\libraries\detaBaseArduinoESP32\src\detaBaseArduinoESP32.cpp:24:15: error: 'class BearSSL::WiFiClientSecure' has no member named 'setCACert'
   24 |   _wifiObject.setCACert(_detaRootCa);
      |               ^~~~~~~~~

exit status 1